### PR TITLE
Retry downloads

### DIFF
--- a/workflow_code/main.nf
+++ b/workflow_code/main.nf
@@ -189,6 +189,7 @@ include { GET_RUNSHEET } from "./modules/create_runsheet.nf"
 
 // Stage raw reads
 include { COPY_READS } from './modules/copy_reads.nf'
+include { COPY_REMOTE_READS } from './modules/copy_reads.nf'
 
 // Read quality check and filtering
 include { FASTQC as RAW_FASTQC ; MULTIQC as RAW_MULTIQC  } from './modules/quality_assessment.nf'

--- a/workflow_code/main.nf
+++ b/workflow_code/main.nf
@@ -281,17 +281,23 @@ workflow {
 
       GET_RUNSHEET.out.version | mix(software_versions_ch) | set{software_versions_ch}
 
+      file_ch.map{
+            row -> deleteWS(row.paired)  == 'true' ? tuple( "${row.sample_id}", ["${row.forward}","${row.reverse}"], deleteWS(row.paired)) : 
+                                tuple( "${row.sample_id}", [("${row.forward}")], deleteWS(row.paired))
+            }.set{reads_ch} 
+
+
    }else{
 
         Channel.fromPath(params.input_file, checkIfExists: true)
            .splitCsv(header:true)
            .set{file_ch}
-   }
-
-    file_ch.map{
-                     row -> deleteWS(row.paired)  == 'true' ? tuple( "${row.sample_id}", [file("${row.forward}"), file("${row.reverse}")], deleteWS(row.paired)) : 
-                                         tuple( "${row.sample_id}", [file("${row.forward}")], deleteWS(row.paired))
+           file_ch.map{
+                row -> deleteWS(row.paired)  == 'true' ? tuple( "${row.sample_id}", [file("${row.forward}"), file("${row.reverse}")], deleteWS(row.paired)) : 
+                                    tuple( "${row.sample_id}", [file("${row.forward}")], deleteWS(row.paired))
                 }.set{reads_ch} 
+   }
+    
 
     // Use original runsheet to preserve sample order
     if(params.accession){
@@ -301,8 +307,15 @@ workflow {
     }
 
     // Stage raw reads with standard naming
-    COPY_READS(reads_ch)
-    staged_reads_ch = COPY_READS.out.raw_reads
+    if(params.accession){
+        COPY_REMOTE_READS(reads_ch)
+        staged_reads_ch = COPY_REMOTE_READS.out.raw_reads
+        
+    }else{
+        COPY_READS(reads_ch)
+        staged_reads_ch = COPY_READS.out.raw_reads
+    }
+
 
     // Read quality check and trimming
     RAW_FASTQC(staged_reads_ch)

--- a/workflow_code/modules/copy_reads.nf
+++ b/workflow_code/modules/copy_reads.nf
@@ -40,3 +40,29 @@ process COPY_READS {
         """
         }
 }
+
+
+process COPY_REMOTE_READS {
+    publishDir "${params.raw_reads_dir}",
+        mode: params.publishDir_mode
+    tag "${ sample_id }"
+
+    input:
+        tuple val(sample_id), val(paths), val(paired)
+
+    output:
+        tuple val(sample_id), path("${sample_id}*.gz"), val(paired), emit: raw_reads
+
+    script:
+        if ( paired == 'true' ) {
+        """
+        wget -O ${sample_id}${params.raw_R1_suffix} '${paths[0]}'
+        wget -O ${sample_id}${params.raw_R2_suffix} '${paths[1]}'
+        """
+        } else {
+        """
+        wget -O ${sample_id}${params.raw_R1_suffix} '${paths[0]}'
+        """
+        }
+
+}

--- a/workflow_code/nextflow.config
+++ b/workflow_code/nextflow.config
@@ -172,6 +172,12 @@ process {
                   errorStrategy = 'retry'
                   publishDir = [path: params.raw_reads_dir, mode: params.publishDir_mode]
             }
+    withName: COPY_REMOTE_READS {
+                  maxRetries = 3
+                  maxForks = 5
+                  errorStrategy = 'retry'
+                  publishDir = [path: params.raw_reads_dir, mode: params.publishDir_mode]
+    }
 
 //********************************** Read quality control and assesment ********************************************//
     withLabel: fastqc {


### PR DESCRIPTION
Separates out the staging of remote input files. Remote input files are now downloaded in a process that can be retried.